### PR TITLE
fix(Testing): Add dependencies and providers for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ lerna-debug.log*
 .data
 /files
 .env
+.env.test
 /ormconfig.json
 *pnpm*

--- a/package.json
+++ b/package.json
@@ -117,6 +117,9 @@
       "ts"
     ],
     "rootDir": "src",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/src/channels/channels.controller.spec.ts
+++ b/src/channels/channels.controller.spec.ts
@@ -1,6 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChannelsController } from './channels.controller';
 import { ChannelsService } from './channels.service';
+import { UsersService } from '../users/users.service';
+import { ChannelRepository } from './infrastructure/persistence/channel.repository';
+import { MessagesService } from '../messages/messages.service';
 
 describe('ChannelsController', () => {
   let controller: ChannelsController;
@@ -8,7 +11,21 @@ describe('ChannelsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ChannelsController],
-      providers: [ChannelsService],
+      providers: [
+        ChannelsService,
+        {
+          provide: UsersService,
+          useValue: {},
+        },
+        {
+          provide: ChannelRepository,
+          useValue: {},
+        },
+        {
+          provide: MessagesService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<ChannelsController>(ChannelsController);

--- a/src/channels/channels.service.spec.ts
+++ b/src/channels/channels.service.spec.ts
@@ -1,12 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChannelsService } from './channels.service';
+import { ChannelRepository } from './infrastructure/persistence/channel.repository';
+import { ChannelRelationalRepository } from './infrastructure/persistence/repositories/channel.repository';
+import { UsersService } from '../users/users.service';
 
 describe('ChannelsService', () => {
   let service: ChannelsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ChannelsService],
+      providers: [
+        ChannelsService,
+        {
+          provide: ChannelRepository,
+          useValue: ChannelRelationalRepository,
+        },
+        {
+          provide: UsersService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<ChannelsService>(ChannelsService);

--- a/src/messages/messages.service.spec.ts
+++ b/src/messages/messages.service.spec.ts
@@ -1,18 +1,32 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MessagesService } from './messages.service';
+import { MessageRelationalRepository } from './infrastructure/presistence/repositories/message.repository';
+import { MessageRepository } from './infrastructure/presistence/message.repository';
 
 describe('MessagesService', () => {
   let service: MessagesService;
+  let messageRepository: MessageRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [MessagesService],
+      providers: [
+        MessagesService,
+        {
+          provide: MessageRepository,
+          useValue: MessageRelationalRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<MessagesService>(MessagesService);
+    messageRepository = module.get<MessageRepository>(MessageRepository);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should be defined', () => {
+    expect(messageRepository).toBeDefined();
   });
 });

--- a/src/workspaces/workspaces.controller.spec.ts
+++ b/src/workspaces/workspaces.controller.spec.ts
@@ -1,5 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { WorkspacesController } from './workspaces.controller';
+import { WorkspacesService } from './workspaces.service';
+import { UsersService } from '../users/users.service';
+import { WorkspaceRepository } from './infrastructure/persistence/workspace.repository';
 
 describe('WorkspacesController', () => {
   let controller: WorkspacesController;
@@ -7,6 +10,17 @@ describe('WorkspacesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [WorkspacesController],
+      providers: [
+        WorkspacesService,
+        {
+          provide: WorkspaceRepository,
+          useValue: {},
+        },
+        {
+          provide: UsersService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<WorkspacesController>(WorkspacesController);

--- a/src/workspaces/workspaces.service.spec.ts
+++ b/src/workspaces/workspaces.service.spec.ts
@@ -1,12 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { WorkspacesService } from './workspaces.service';
+import { WorkspaceRepository } from './infrastructure/persistence/workspace.repository';
+import { WorkspaceRelationalRepository } from './infrastructure/persistence/repositories/workspace.repository';
+import { UsersService } from '../users/users.service';
 
 describe('WorkspacesService', () => {
   let service: WorkspacesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [WorkspacesService],
+      providers: [
+        WorkspacesService,
+        {
+          provide: WorkspaceRepository,
+          useValue: WorkspaceRelationalRepository,
+        },
+        {
+          provide: UsersService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<WorkspacesService>(WorkspacesService);


### PR DESCRIPTION
#59 
Just add a `.env.test` file with the same environment variables we have for now and change the environment to `test` and run :).