### PR TITLE
Stop using `eager` to load related entities

### DIFF
--- a/src/channels/infrastructure/persistence/entities/channel.entity.ts
+++ b/src/channels/infrastructure/persistence/entities/channel.entity.ts
@@ -37,9 +37,7 @@ export class ChannelEntity extends EntityRelationalHelper implements Channel {
   @ManyToOne(() => ChannelTypeEntity)
   type?: ChannelTypeEntity;
 
-  @ManyToMany(() => UserEntity, (user) => user.channels, {
-    eager: true,
-  })
+  @ManyToMany(() => UserEntity, (user) => user.channels)
   @JoinTable()
   members: UserEntity[];
 
@@ -55,8 +53,6 @@ export class ChannelEntity extends EntityRelationalHelper implements Channel {
   @DeleteDateColumn()
   deletedAt: Date;
 
-  @ManyToOne(() => WorkspaceEntity, (workspace) => workspace.channels, {
-    eager: true,
-  })
+  @ManyToOne(() => WorkspaceEntity, (workspace) => workspace.channels)
   workspace: WorkspaceEntity;
 }

--- a/src/messages/domain/message.ts
+++ b/src/messages/domain/message.ts
@@ -1,17 +1,18 @@
 import { Channel } from 'src/channels/domain/channel';
 import { User } from 'src/users/domain/user';
+import { DeepPartial } from 'src/utils/types/deep-partial.type';
 import { Workspace } from 'src/workspaces/domain/workspace';
 
 export class Message {
   id: number | string;
   content: string;
   childsCount: number;
-  sender: User;
-  channel: Channel;
+  sender: DeepPartial<User>;
+  channel: DeepPartial<Channel>;
   createdAt: Date;
   updatedAt: Date;
   deletedAt: Date;
-  workspace: Workspace;
+  workspace: DeepPartial<Workspace>;
   parentMessage?: Message;
   participants: User[];
   draft: boolean;

--- a/src/messages/infrastructure/persistence/entities/message.entity.ts
+++ b/src/messages/infrastructure/persistence/entities/message.entity.ts
@@ -31,14 +31,10 @@ export class MessageEntity extends EntityRelationalHelper implements Message {
   @Column({ default: false })
   draft: boolean;
 
-  @ManyToOne(() => UserEntity, {
-    eager: true,
-  })
+  @ManyToOne(() => UserEntity)
   sender: UserEntity;
 
-  @ManyToOne(() => ChannelEntity, (channel) => channel.messages, {
-    eager: true,
-  })
+  @ManyToOne(() => ChannelEntity, (channel) => channel.messages)
   channel: ChannelEntity;
 
   @CreateDateColumn()
@@ -50,9 +46,7 @@ export class MessageEntity extends EntityRelationalHelper implements Message {
   @DeleteDateColumn()
   deletedAt: Date;
 
-  @ManyToOne(() => WorkspaceEntity, {
-    eager: true,
-  })
+  @ManyToOne(() => WorkspaceEntity)
   workspace: WorkspaceEntity;
 
   @ManyToOne(() => MessageEntity)

--- a/src/messages/infrastructure/persistence/mappers/message.mapper.ts
+++ b/src/messages/infrastructure/persistence/mappers/message.mapper.ts
@@ -1,8 +1,5 @@
 import { Message } from 'src/messages/domain/message';
 import { MessageEntity } from '../entities/message.entity';
-import { UserMapper } from 'src/users/infrastructure/persistence/relational/mappers/user.mapper';
-import { ChannelMapper } from 'src/channels/infrastructure/persistence/mappers/channel.mapper';
-import { WorkspaceMapper } from 'src/workspaces/infrastructure/persistence/mappers/workspace.mapper';
 import { UserEntity } from 'src/users/infrastructure/persistence/relational/entities/user.entity';
 import { ChannelEntity } from 'src/channels/infrastructure/persistence/entities/channel.entity';
 import { WorkspaceEntity } from 'src/workspaces/infrastructure/persistence/entities/workspace.entity';
@@ -17,9 +14,15 @@ export class MessageMapper {
     message.draft = raw.draft;
     message.updatedAt = raw.updatedAt;
     message.deletedAt = raw.deletedAt;
-    message.sender = UserMapper.toDomain(raw.sender);
-    message.channel = ChannelMapper.toDomain(raw.channel);
-    message.workspace = WorkspaceMapper.toDomain(raw.workspace);
+    message.sender = {
+      id: raw.sender.id,
+      firstName: raw.sender.firstName,
+      photo: raw.sender.photo,
+    };
+    message.channel = {
+      id: raw.channel.id,
+    };
+    message.workspace = raw.workspace;
 
     return message;
   }

--- a/src/messages/infrastructure/persistence/repositories/message.repository.ts
+++ b/src/messages/infrastructure/persistence/repositories/message.repository.ts
@@ -19,6 +19,7 @@ import { Workspace } from 'src/workspaces/domain/workspace';
 import { MessageRepository } from '../message.repository';
 import { EntityCondition } from 'src/utils/types/entity-condition.type';
 import { NullableType } from 'src/utils/types/nullable.type';
+import { loadRelationships } from 'src/utils/load-relationships';
 
 @Injectable()
 export class MessageRelationalRepository implements MessageRepository {
@@ -41,6 +42,13 @@ export class MessageRelationalRepository implements MessageRepository {
     const entity = await this.messageRepository.findOne({
       where: fields as FindOptionsWhere<MessageEntity>,
     });
+
+    await loadRelationships(
+      this.messageRepository,
+      ['channel', 'sender'],
+      [entity],
+    );
+
     return entity ? MessageMapper.toDomain(entity) : null;
   }
 

--- a/src/utils/load-relationships.ts
+++ b/src/utils/load-relationships.ts
@@ -1,0 +1,34 @@
+import { Repository, In } from 'typeorm';
+
+export async function loadRelationships(
+  repo: Repository<any>,
+  relationships: string[],
+  baseEntities: any[],
+) {
+  if (!baseEntities) {
+    baseEntities = await repo.find({});
+  }
+
+  const baseEntityIds = baseEntities.map((entity) => entity.id).filter(Boolean);
+
+  const { ...relatedEntities } = await Promise.all(
+    relationships.map(async (relation) => {
+      const related = await repo.find({
+        where: { id: In(baseEntityIds) },
+        relations: [relation],
+      });
+
+      return related;
+    }),
+  );
+
+  Object.keys(relatedEntities).forEach((i) => {
+    relatedEntities[i].forEach((r) => {
+      const fullEntity = baseEntities.find((e) => e.id === r.id);
+      if (fullEntity) {
+        const relationship = relationships[i];
+        fullEntity[relationship] = r[relationship];
+      }
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces the `loadRelationships` function, designed to significantly enhance the efficiency of loading related entities within our project. By loading of multiple relationships for a given set of base entities into a single batch operation, this function effectively reduces the number of database queries, thereby improving overall performance.

Additionally, this PR demonstrates the usage of `loadRelationships` by updating the `MessageRepository`. This serves as an example of how to utilize the function to optimize entity relationship loading. Notably, this update contributes to reducing the response body size, and enhancing the application's efficiency and responsiveness.

Closes #84 