### PR TITLE
Refactor `getWorkspaceChannels` to get only user joined channels

### DIFF
--- a/src/channels/channels.module.ts
+++ b/src/channels/channels.module.ts
@@ -15,5 +15,6 @@ import { UsersModule } from '../users/users.module';
   ],
   controllers: [ChannelsController],
   providers: [ChannelsService],
+  exports: [ChannelsService],
 })
 export class ChannelsModule {}

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -19,6 +19,7 @@ import {
   FilterMessageDto,
   SortMessageDto,
 } from 'src/messages/dto/query-message.dto';
+import { FilterChannelDto, SortChannelDto } from './dto/query-channel.dto';
 
 @Injectable()
 export class ChannelsService {
@@ -88,6 +89,21 @@ export class ChannelsService {
     });
   }
 
+  findManyWithPagination({
+    filterOptions,
+    sortOptions,
+    paginationOptions,
+  }: {
+    filterOptions?: FilterChannelDto | null;
+    sortOptions?: SortChannelDto[] | null;
+    paginationOptions: IPaginationOptions;
+  }): Promise<Channel[]> {
+    return this.channelRepostory.findManyWithPagination({
+      filterOptions,
+      sortOptions,
+      paginationOptions,
+    });
+  }
   async softDelete(user: User, id: Channel['id']): Promise<void> {
     const channel = await this.channelRepostory.findOne({ id });
     if (!channel) {

--- a/src/channels/dto/query-channel.dto.ts
+++ b/src/channels/dto/query-channel.dto.ts
@@ -1,0 +1,74 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform, Type, plainToInstance } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Channel } from 'diagnostics_channel';
+import { User } from 'src/users/domain/user';
+import { Workspace } from 'src/workspaces/domain/workspace';
+
+export class FilterChannelDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => Workspace)
+  workspaceId?: Workspace['id'] | null;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => User)
+  userId?: User['id'] | null;
+}
+
+export class SortChannelDto {
+  @ApiProperty()
+  @IsString()
+  orderBy: keyof Channel;
+
+  @ApiProperty()
+  @IsString()
+  order: string;
+}
+
+export class QueryChannelDto {
+  @ApiProperty({
+    required: false,
+  })
+  @Transform(({ value }) => (value ? Number(value) : 1))
+  @IsNumber()
+  @IsOptional()
+  page: number;
+
+  @ApiProperty({
+    required: false,
+  })
+  @Transform(({ value }) => (value ? Number(value) : 10))
+  @IsNumber()
+  @IsOptional()
+  limit: number;
+
+  @ApiProperty({ type: String, required: false })
+  @IsOptional()
+  @Transform(({ value }) =>
+    value ? plainToInstance(FilterChannelDto, JSON.parse(value)) : undefined,
+  )
+  @ValidateNested()
+  @Type(() => FilterChannelDto)
+  filters?: FilterChannelDto | null;
+
+  @ApiProperty({ type: String, required: false })
+  @IsOptional()
+  @Transform(({ value }) => {
+    return value
+      ? plainToInstance(SortChannelDto, JSON.parse(value))
+      : undefined;
+  })
+  @ValidateNested({ each: true })
+  @Type(() => SortChannelDto)
+  sort?: SortChannelDto[] | null;
+}

--- a/src/channels/infrastructure/persistence/channel.repository.ts
+++ b/src/channels/infrastructure/persistence/channel.repository.ts
@@ -2,8 +2,15 @@ import { Channel } from 'src/channels/domain/channel';
 import { EntityCondition } from 'src/utils/types/entity-condition.type';
 import { NullableType } from 'src/utils/types/nullable.type';
 import { DeepPartial } from 'typeorm';
-import { ICursorPaginationOptions } from '../../../utils/types/pagination-options';
+import {
+  ICursorPaginationOptions,
+  IPaginationOptions,
+} from '../../../utils/types/pagination-options';
 import { Message } from '../../../messages/domain/message';
+import {
+  FilterChannelDto,
+  SortChannelDto,
+} from 'src/channels/dto/query-channel.dto';
 
 export abstract class ChannelRepository {
   abstract create(
@@ -16,6 +23,16 @@ export abstract class ChannelRepository {
   abstract findOne(
     fields: EntityCondition<Channel>,
   ): Promise<NullableType<Channel>>;
+
+  abstract findManyWithPagination({
+    filterOptions,
+    sortOptions,
+    paginationOptions,
+  }: {
+    filterOptions?: FilterChannelDto | null;
+    sortOptions?: SortChannelDto[] | null;
+    paginationOptions: IPaginationOptions;
+  }): Promise<Channel[]>;
 
   abstract update(
     id: Channel['id'],

--- a/src/channels/infrastructure/persistence/repositories/channel.repository.ts
+++ b/src/channels/infrastructure/persistence/repositories/channel.repository.ts
@@ -71,7 +71,7 @@ export class ChannelRelationalRepository {
 
     return entities.map((channel) => ChannelMapper.toDomain(channel));
   }
-  
+
   async checkUserMembership(
     channelId: Channel['id'],
     memberId: User['id'],

--- a/src/channels/infrastructure/persistence/repositories/channel.repository.ts
+++ b/src/channels/infrastructure/persistence/repositories/channel.repository.ts
@@ -6,8 +6,10 @@ import { Channel } from 'src/channels/domain/channel';
 import { Injectable } from '@nestjs/common';
 import { NullableType } from 'src/utils/types/nullable.type';
 import { EntityCondition } from 'src/utils/types/entity-condition.type';
-import { FilterChannelDto } from 'src/channels/dto/query-channel.dto';
-import { SortUserDto } from 'src/users/dto/query-user.dto';
+import {
+  FilterChannelDto,
+  SortChannelDto,
+} from 'src/channels/dto/query-channel.dto';
 import { IPaginationOptions } from 'src/utils/types/pagination-options';
 
 @Injectable()
@@ -40,7 +42,7 @@ export class ChannelRelationalRepository {
     paginationOptions,
   }: {
     filterOptions?: FilterChannelDto | null;
-    sortOptions?: SortUserDto[] | null;
+    sortOptions?: SortChannelDto[] | null;
     paginationOptions: IPaginationOptions;
   }): Promise<Channel[]> {
     const where: FindOptionsWhere<ChannelEntity> = {};

--- a/src/workspaces/workspaces.module.ts
+++ b/src/workspaces/workspaces.module.ts
@@ -6,12 +6,14 @@ import { UsersModule } from '../users/users.module';
 import { MessagesModule } from '../messages/messages.module';
 import { InvitesModule } from 'src/invites/invites.module';
 import { FilesModule } from 'src/files/files.module';
+import { ChannelsModule } from 'src/channels/channels.module';
 
 @Module({
   imports: [
     WorkspacePersistenceModule,
     UsersModule,
     MessagesModule,
+    ChannelsModule,
     InvitesModule,
     FilesModule,
   ],


### PR DESCRIPTION
resolves #88 
This PR introduces breaking changes to the end point `GET: /workspaces/{id}/channels` and the return value structure has been changed to support infinity pagination and to take filter, sort, pagination options params instead of just the workspaceId.